### PR TITLE
cli/gh-extension-precompile env:  CGO_ENABLED: 0

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -37,5 +37,7 @@ jobs:
           GH_TOKEN: dummy-token-to-facilitate-rest-client
 
       - uses: cli/gh-extension-precompile@v1
+        env:
+          CGO_ENABLED: 0
         with:
           go_version: "1.18"


### PR DESCRIPTION
set env: CGO_ENABLED: 0
for cli/gh-extension-precompile
should fix  https://github.com/actions/gh-actions-cache/issues/56

### What are you trying to accomplish?

<!-- Provide a description of the changes, including any screenshots, videos, or graphs if applicable. Link to any related issues or projects here. -->

### What approach did you choose and why?

<!-- This section is a place for you to describe your thought process in making these changes. List any tradeoffs you made to take on or pay down tech debt. Identify any work you did to mitigate risk. Describe any alternative approaches you considered and why you discarded them. -->

### Anything you want to highlight for special attention from reviewers?

<!-- This is your chance to identify remaining risks and confess any uncertainties you may have about the correctness of the changes. Highlight anything on which you would like a second (or third) opinion. -->